### PR TITLE
fixbug: object size should be lineEnd+2 rather than lineEnd+1

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -103,7 +103,7 @@ func (r *Reader) indexObjectEnd(start int) int {
 		if lineEnd < 0 {
 			return -1
 		}
-		if lineEnd+1 < MIN_OBJECT_LENGTH {
+		if lineEnd+2 < MIN_OBJECT_LENGTH {
 			r.err = ErrSyntaxError
 			return -1
 		}

--- a/reader_test.go
+++ b/reader_test.go
@@ -42,6 +42,8 @@ func TestReadObjectSlice_Valid(t *testing.T) {
 		{[]byte("*2\r\n*1\r\n-OK\r\n*1\r\n-OK\r\n"), []byte("*2\r\n*1\r\n-OK\r\n*1\r\n-OK\r\n")},
 		// array with null bulk string
 		{[]byte("*3\r\n$3\r\nfoo\r\n$-1\r\n$3\r\nbar\r\n"), []byte("*3\r\n$3\r\nfoo\r\n$-1\r\n$3\r\nbar\r\n")},
+		// array with 1 byte length integer
+		{[]byte("*3\r\n*4\r\n:5462\r\n:10922\r\n*2\r\n$9\r\n127.0.0.1\r\n:7932\r\n*2\r\n$9\r\n127.0.0.1\r\n:8032\r\n*4\r\n:0\r\n:5461\r\n*2\r\n$9\r\n127.0.0.1\r\n:7931\r\n*2\r\n$9\r\n127.0.0.1\r\n:8031\r\n*3\r\n:10923\r\n:16383\r\n*2\r\n$9\r\n127.0.0.1\r\n:7933\r\n"), []byte("*3\r\n*4\r\n:5462\r\n:10922\r\n*2\r\n$9\r\n127.0.0.1\r\n:7932\r\n*2\r\n$9\r\n127.0.0.1\r\n:8032\r\n*4\r\n:0\r\n:5461\r\n*2\r\n$9\r\n127.0.0.1\r\n:7931\r\n*2\r\n$9\r\n127.0.0.1\r\n:8031\r\n*3\r\n:10923\r\n:16383\r\n*2\r\n$9\r\n127.0.0.1\r\n:7933\r\n")},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
I have added a test case to reader_test which can not pass. By debuging for a while, I found that calculating the size of String is wrong. Index of '\r\n' in ':0\r\n' is 2 not 3, so size of ':0\r\n' should be index + 2。
